### PR TITLE
Minor optimizations

### DIFF
--- a/Einführung in Strings/CStrings/CStrings/CStrings.cpp
+++ b/Einführung in Strings/CStrings/CStrings/CStrings.cpp
@@ -9,14 +9,14 @@
 #include <iostream>
 
 /*
-    C-Strings sind tatsächlich eindimensionale Arrays, 
-    die durch ein Nullzeichen '\0' abgeschlossen werden. 
-    Somit enthält ein nullterminierter String die Zeichen, 
+    C-Strings sind tatsächlich eindimensionale Arrays,
+    die durch ein Nullzeichen '\0' abgeschlossen werden.
+    Somit enthält ein nullterminierter String die Zeichen,
     aus denen die String besteht, gefolgt von einer Null.
 
-    Die folgende Deklaration und Initialisierung erstellt ein String, 
-    der aus dem Wort "Hallo" besteht. Um das Nullzeichen am Ende des Arrays zu halten, 
-    ist die Größe des Zeichenarrays, das die Zeichenfolge enthält, 
+    Die folgende Deklaration und Initialisierung erstellt ein String,
+    der aus dem Wort "Hallo" besteht. Um das Nullzeichen am Ende des Arrays zu halten,
+    ist die Größe des Zeichenarrays, das die Zeichenfolge enthält,
     eins größer als die Anzahl der Zeichen im Wort "Hallo".
 */
 
@@ -30,18 +30,18 @@ int main()
     //1. Art ein C-String zu definieren: ( hier muss man nicht auf das '\0' achten!)
     char text2[] = "Hello";
 
-    //Beispiel das einlesen und wieder ausgeben von bustaben:
+    //Beispiel das einlesen und wieder ausgeben von buchstaben:
 
-    //bustaben mit 20 zeichen (inclusive '\0')
-    char bustaben[20+1];
+    //buchstaben mit 20 zeichen (inclusive '\0')
+    char buchstaben[20+1];
     
-    //getline benötigt 2 Parameter, der erste ist die Variable welcher der Wert der Eingabe zugewiesen werden soll
-    // der zweite die größe des pointers/arrays, dies kann man mit sizeof() machen
-    std::cin.getline(bustaben, sizeof(bustaben));
+    //getline benötigt 2 Parameter, der erste ist die Variable welcher der Wert der Eingabe zugewiesen werden soll,
+    //der zweite ist die Anzahl an Zeichen mit Nullterminator, dies kann man mit sizeof() machen
+    std::cin.getline(buchstaben, sizeof(buchstaben));
 
 
     //Ausgabe:
-    std::cout << "Deine Eingabe (20 Zeichen): " << bustaben << std::endl;
+    std::cout << "Deine Eingabe (20 Zeichen): " << buchstaben << "\n";
 
 
     //Formatierte Ausgabe, zb nur jeder 2.te Bustabe
@@ -49,11 +49,11 @@ int main()
     //Eingabe : AaBbCcDdEeFfGg
     //Ausgabe : ABCDEFG
 
-    std::cout << "Deine Formatierte ausgabe: ";
-    for (int i = 0; i < strlen(bustaben); i++)
+    std::cout << "Deine Formatierte Ausgabe: ";
+    for (int i = 0; i < strlen(buchstaben); i++)
     {
         
-        if(i % 2 == 0) std::cout << bustaben[i];
+        if(i % 2 == 0) std::cout << buchstaben[i];
     }
     //Der C-String braucht noch ein '\0'
     std::cout << '\0';

--- a/Einführung in Strings/Strings/Strings/Strings.cpp
+++ b/Einführung in Strings/Strings/Strings/Strings.cpp
@@ -48,7 +48,7 @@ int main()
     */
  
     str3 = str1;
-    std::cout << "str3 : " << str3 << std::endl;
+    std::cout << "str3 : " << str3 << "\n";
 
     /*
         Erklärung der Zeile "str3 = str1"
@@ -62,7 +62,7 @@ int main()
 
     */
     str3 = str1 + str2;
-    std::cout << "str1 + str2 : " << str3 << std::endl;
+    std::cout << "str1 + str2 : " << str3 << "\n";
 
     
     /*
@@ -73,14 +73,14 @@ int main()
 
     */
 
-    std::cout << "str3.size() :  " << str3.size() << std::endl;
+    std::cout << "str3.size() :  " << str3.size() << "\n";
 
 
     /*
        Länge eines Strings mit "length"
     
     */
-    std::cout << "str3.length() :  " << str3.length() << std::endl;
+    std::cout << "str3.length() :  " << str3.length() << "\n";
 
     /*
         Zugriff auf die Strings:
@@ -88,7 +88,7 @@ int main()
         Auf Strings kann wie ein Feld (Array) zugreifen, hier ein Beispiel wie man das erste Zeichen von "Hallo" ausgibt
 
     */
-    std::cout << "Erste Zeichen von 'Hallo' :  " << str1[0] << std::endl;
+    std::cout << "Erstes Zeichen von \"Hallo\" :  " << str1[0] << "\n";
 
 
     /*
@@ -98,8 +98,8 @@ int main()
 
     */
     str3[0] = 'S';
-    std::cout << "Manipulierter String :  " << str1 << std::endl;
-    std::cout << "Erste Zeichen von 'Hallo' :  " << str1[0] << std::endl;
+    std::cout << "Manipulierter String :  " << str1 << "\n";
+    std::cout << "Erstes Zeichen von \"Hallo\" :  " << str1[0] << "\n";
 
 
     /*
@@ -114,10 +114,10 @@ int main()
         
     */
     std::string Name;
-    std::cout << "Namen eingeben: " << Name << std::endl;
+    std::cout << "Namen eingeben: " << Name << "\n";
     std::getline(std::cin, Name);
     
-    std::cout << "Eingelesener String: " << Name << std::endl;
+    std::cout << "Eingelesener String: " << Name << "\n";
 
 
     (void)getchar();

--- a/Erweitert/Arrays/Arrays/Arrays.cpp
+++ b/Erweitert/Arrays/Arrays/Arrays.cpp
@@ -31,7 +31,7 @@ int main()
 
     //Folgendes gibt "Tesla" aus.
 
-    std::cout << "E-Auto ist: " << cars[0] << std::endl;
+    std::cout << "E-Auto ist: " << cars[0] << "\n";
 
 
     /*
@@ -39,7 +39,7 @@ int main()
         Der Index 0 wird mit einem neuen Wert überschrieben, also statt "Tesla" nun "Opel"
     */
     cars[0] = "Opel";
-    std::cout << "Auto waere nun ein: " << cars[0] << std::endl;
+    std::cout << "Auto waere nun ein: " << cars[0] << "\n";
 
     /*
     Arrays in Verbindung mit Schleifen
@@ -48,28 +48,26 @@ int main()
     */
     for (int i = 0; i < 4; i++) {
         //i startet bei 0, somit wird wie wir oben gelernt haben der erste Wert ausgeben usw. bis 4
-        std::cout << cars[i] << std::endl;
+        std::cout << cars[i] << "\n";
     }
-    /*
-    Eine Schleife die 5 Werte nacheinander einließt und alle werte in das array "zahlen" speichert
-    
-    */
+
+    //Eine Schleife die 5 Werte nacheinander einließt und alle werte in das Array "zahlen" speichert
     const int wert = 5;
     int zahlen[wert];
     for (size_t i = 0; i < wert; i++)
     {
-        std::cout << "Bitte gebe die Zahl für die Stelle #" << i << " ein: " << std::endl;
+        std::cout << "Bitte gebe die Zahl für die Stelle #" << i << " ein: " << "\n";
         // Auf die Elemente des Arrays wird wie gewohnt zugegriffen.
         std::cin >> zahlen[i];
-        std::cout << std::endl;
+        std::cout << "\n";
         
     }
 
-    //Alle werte ausgeben:
+    //Alle Werte ausgeben:
     for (size_t i = 0; i < wert; i++)
     {
         // Auf die Elemente des Arrays wird wie gewohnt zugegriffen.
-        std::cout << "Wert an stelle #" << i << " " << zahlen[i] << std::endl;
+        std::cout << "Wert an stelle #" << i << " " << zahlen[i] << "\n";
     }
 
     (void)getchar();

--- a/Erweitert/Funktionen/Funktionen/Funktionen.cpp
+++ b/Erweitert/Funktionen/Funktionen/Funktionen.cpp
@@ -6,32 +6,34 @@
 */
 #include <iostream>
 
-//Das ist ein Prototyp einer Funktion, es deklariert den RückgabeTyp, die jeweiligen Datentypen der Parameter wenn benötigt
-//Dies muss nicht zwingend gemacht werden, ist aber hilfreich bei der späteren Ansicht des Codes was man da gemacht hat.
-//Außerdem MUSS dies gemacht werden wenn die Funktion unterhalb der "int main" funktion deklariert ist.
+/*
+    Das ist ein Prototyp einer Funktion, es deklariert den RückgabeTyp, die jeweiligen Datentypen der Parameter wenn benötigt
+    Dies muss nicht zwingend gemacht werden, ist aber hilfreich bei der späteren Ansicht des Codes was man da gemacht hat.
+    Außerdem MUSS dies gemacht werden wenn die Funktion unterhalb der "int main" funktion deklariert ist.
+*/
 int max(int, int);
 
 /*
-    Parameter sind Übergabewerte an Funktion, eine Funktion muss keine Parameter besitzen, 
-    wenn ja muss beim aufruf auch die Anzahl der Parameter übergeben werden 
+    Parameter sind Übergabewerte an Funktion, eine Funktion muss keine Parameter besitzen,
+    wenn ja muss beim aufruf auch die Anzahl der Parameter übergeben werden
     die im Prototype bzw. in der Funktion Deklaration definiert sind.
 
 */
 
 
-//Definierung der Funktion, der RückgabeTyp entspricht hier "int" ein "int" MUSS auch zurückgegeben werden!
+//Definition der Funktion, der Rückgabetyp entspricht hier "int": ein "int" MUSS auch zurückgegeben werden!
 int max(int zahl1, int zahl2) {
-    //Return wert, "return" gibt nur etwas zurück, NICHT aus, es ist also nicht dasselbe wie "cout" !
+    //Returnwert, "return" gibt nur etwas zurück, NICHT aus, es ist also nicht dasselbe wie "cout" !
     return (zahl1 > zahl2) ? zahl1 : zahl2; //Das ist ein tenärer Operator, den kann ich auf Anfrage gerne auch erklären
 }
 
 /*
     Überladung von Funktionen:
     Beispiel: Du hast 2 Funktionen die dir das maximum von 2 Zahlen liefern, eine für integer und eine für double
-    Wenn es 2 oder mehrere Funktionen gibt die das selbe machen, ist es besser sie zu überladen, 
-    d.h wir definieren sie alle mit dem selben Namen, 
-    müssen aber entweder die Parameter Anzahl oder Datentyp ändern, 
-    da 2 exakt gleiche Funktion einen Fehler werfen.  
+    Wenn es 2 oder mehrere Funktionen gibt die das selbe machen, ist es besser sie zu überladen,
+    d.h wir definieren sie alle mit dem selben Namen,
+    müssen aber entweder die Parameter Anzahl oder Datentyp ändern,
+    da 2 exakt gleiche Funktion einen Fehler werfen.
 
     Beispiel für das maximum Problem:
 */
@@ -53,28 +55,28 @@ int max(int zahl1, int zahl2) {
 
 /*
     Das ist die Main Funktion
-    der C++ Compiler benötigt sie um zu kompilieren,
-    die ist der Startpunkt jedes Projektes
+    Der C++-Compiler benötigt sie, um zu kompilieren
+    Sie ist der Startpunkt jedes Projektes
 */
 
 int main()
 {
     //Hier rufen wir unsere Funktion mal auf. Es gibt da mehrere Wege:
     //1. Sofort ausgeben:
-    std::cout << "Maximum von 1 und 2: " << max(1, 2) << std::endl;
+    std::cout << "Maximum von 1 und 2: " << max(1, 2) << "\n";
     //2. in einer Variable speichern:
     int Maximum = max(1, 2); //Gibt 2 zurück
     //3. in anderen Funktionen nutzen oder in rechnungen:
     Maximum += max(5, 3); //gibt 2 + 5 = 7 zurück, da maximum ja mit dem wert 2 schon deklariert ist + dem maximum aus 5 und 3
 
     //Hier die Ausgabe der Überladung von Funktionen:
-    std::cout << "Maximum von 2 Zahlen (Ueberladung): " << maximum(1, 2) << std::endl;
+    std::cout << "Maximum von 2 Zahlen (Ueberladung): " << maximum(1, 2) << "\n";
     //Genau die Selbe Funktion, allerdings mit double Parameters
-    std::cout << "Maximum von 2 Zahlen (Ueberladung): " << maximum(1.2, 2.3) << std::endl;
+    std::cout << "Maximum von 2 Zahlen (Ueberladung): " << maximum(1.2, 2.3) << "\n";
 
 
 
     (void)getchar();
-    //Auch das ist wieder eine Funktion die ein "int" als return typ benötigt also "return 0"
+    //Auch das ist wieder eine Funktion die ein "int" als return type benötigt, daher "return 0"
     return 0;
 }

--- a/Erweitert/Pointers/Pointers/Pointers.cpp
+++ b/Erweitert/Pointers/Pointers/Pointers.cpp
@@ -27,11 +27,11 @@ int main()
     //Ein Beispiel eines int Pointers das beliebig viele Zufallszahlen in ein Array einließt
 
     int wert;
-    std::cout << "Anzahl der Werte :" << std::endl;
+    std::cout << "Anzahl der Werte :" << "\n";
     std::cin >> wert;
     //"nullptr" wird benötigt um den pointer zu initialisieren
     int* pointer = nullptr;
-    //Pointer zu einen neuen int array konvertieren, wenn deklariert kann vorher die "nullptr" deklaration weggelassen werden!
+    //Pointer zu einen neuen int array konvertieren, wenn er schon deklariert ist, kann vorher die "nullptr" deklaration weggelassen werden!
     pointer = new int[wert];
 
     for (size_t i = 0; i < wert; i++)
@@ -44,7 +44,7 @@ int main()
     for (size_t i = 0; i < wert; i++)
     {
         // Auf die Elemente des Arrays wird wie gewohnt zugegriffen.
-        std::cout << "Zufallszahl #" << i << " "<< pointer[i] << std::endl; 
+        std::cout << "Zufallszahl #" << i << " "<< pointer[i] << "\n"; 
     }
 
 

--- a/Erweitert/Referenz/Referenz/Referenz.cpp
+++ b/Erweitert/Referenz/Referenz/Referenz.cpp
@@ -20,14 +20,14 @@ int main()
     */
 
 
-    std::cout << "Name: " << Name << std::endl;  // Gibt "Sebastian" aus
-    std::cout << "Referenz von Name: " << Benutzername << std::endl;  // Gibt "Sebastian" aus
+    std::cout << "Name: " << Name << "\n";  // Gibt "Sebastian" aus
+    std::cout << "Referenz von Name: " << Benutzername << "\n";  // Gibt "Sebastian" aus
 
 
     /*
     Speicherplatz einer Variable durch die Referenz ausgeben:
     */
-    std::cout << "Speicherplatz der Variable Name: " << &Name << std::endl;
+    std::cout << "Speicherplatz der Variable Name: " << &Name << "\n";
 
     (void)getchar();
     return 0;

--- a/Erweitert/Switch/Switch/Switch.cpp
+++ b/Erweitert/Switch/Switch/Switch.cpp
@@ -10,10 +10,10 @@
 int main()
 {
    /*
-    Ein Switch ist sozusagen eine verkürzte Schreibweise zu einem if else if else usw.
-    Jeder Case ist die Bedinung also der case mit der 1 , heißt in der if : if(day == 1)
-    Wenn der Case zutrifft wird dieser ausgeführt und mit break beendet, damit nicht die andern
-    cases geprüft werden.
+    Ein Switch ist sozusagen eine verkürzte Schreibweise zu einem if - else if - else usw.
+    Jeder Case ist die Bedingung, also der Case mit der 1 entspricht if(day == 1)
+    Wenn der Case zutrifft wird dieser ausgeführt und mit break beendet, damit nicht die anderen
+    Cases geprüft werden.
    */
 
     int day = 4;

--- a/OOP Einführung/Namensräume/Namensräume/Namensräume.cpp
+++ b/OOP Einführung/Namensräume/Namensräume/Namensräume.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 
 /*
-    Ein Namensraum ist eine Virtuelle Abtrennung bzw. Verzeichniss um in der Objekt Orientierten Programmierung 
+    Ein Namensraum ist eine Virtuelle Abtrennung bzw. Verzeichniss um in der Objekt Orientierten Programmierung
     Klassen, Funktion und Structs usw. zu organisieren.
 
     Einen Namensraum kennt Ihr schon, den "std", in diesem sind einfach Funktionen hinterlegt áuf die man so zugreifen kann:

--- a/OOP Einführung/Namensräume/Namensräume/Namensräume.cpp
+++ b/OOP Einführung/Namensräume/Namensräume/Namensräume.cpp
@@ -80,11 +80,11 @@ int main()
     */
 
     //Ausgabe : Sebastian
-    std::cout << Benutzer::BenutzerName << std::endl;
+    std::cout << Benutzer::BenutzerName << "\n";
 
     //Hier die Ausgabe von "ü" aus dem Namespace "Umlaute":
 
-    std::cout << "Unser ue : " << Umlaute::ue << std::endl;
+    std::cout << "Unser ue : " << Umlaute::ue << "\n";
 
     
     (void)getchar();

--- a/OOP Einführung/Structs/Structs/Structs.cpp
+++ b/OOP Einführung/Structs/Structs/Structs.cpp
@@ -7,13 +7,13 @@
 
 #include <iostream>
 /*
-    Mit C / C ++ - Arrays könnt Ihr Variablen definieren, 
-    die mehrere Datenelemente derselben Art kombinieren. 
-    Die Struktur ist jedoch ein anderer benutzerdefinierter Datentyp, 
+    Mit C / C ++ - Arrays könnt Ihr Variablen definieren,
+    die mehrere Datenelemente derselben Art kombinieren.
+    Die Struktur ist jedoch ein anderer benutzerdefinierter Datentyp,
     mit dem Ihr Datenelemente verschiedener Art kombinieren können.
 
-    Strukturen werden verwendet, um einen Datensatz darzustellen. Angenommen, 
-    ihr möchtet eure Bücher in einer Bibliothek verfolgen. 
+    Strukturen werden verwendet, um einen Datensatz darzustellen. Angenommen,
+    ihr möchtet eure Bücher in einer Bibliothek verfolgen.
     Möglicherweise möchtet Ihr die folgenden Attribute für jedes Buch verfolgen:
 
         -Titel
@@ -23,8 +23,8 @@
 
         Struktur definieren
 
-    Um eine Struktur zu definieren, müsst ihr die struct-Anweisung verwenden. 
-    Die struct-Anweisung definiert einen neuen Datentyp mit mehr als einem Mitglied. 
+    Um eine Struktur zu definieren, müsst ihr die struct-Anweisung verwenden.
+    Die struct-Anweisung definiert einen neuen Datentyp mit mehr als einem Mitglied.
     Eine struct-Anweisung ist folgendermaßen aufgebaut:
 
     struct [Struktur-Tag] {
@@ -33,11 +33,11 @@
         Mitgliedsdefinition;
     } [eine oder mehrere Strukturvariablen];
 
-    Das Struktur-Tag ist optional und jede Elementdefinition ist eine normale Variablendefinition, 
-    z. B. int i; oder float f; 
-    oder eine andere gültige Variablendefinition. 
-    Am Ende der Strukturdefinition könnt Ihr vor dem letzten Semikolon eine oder mehrere Strukturvariablen angeben, 
-    dies ist jedoch optional. Hier ist die Art und Weise, 
+    Das Struktur-Tag ist optional und jede Elementdefinition ist eine normale Variablendefinition,
+    z. B. int i; oder float f;
+    oder eine andere gültige Variablendefinition.
+    Am Ende der Strukturdefinition könnt Ihr vor dem letzten Semikolon eine oder mehrere Strukturvariablen angeben,
+    dies ist jedoch optional. Hier ist die Art und Weise,
     wie Ihr die Buchstruktur deklarieren würdet:
     Mit Strukturvariable
 */
@@ -66,10 +66,10 @@ int main()
 
 
     /*
-        Um auf ein Mitglied einer Struktur zuzugreifen, verwenden wir den Elementzugriffsoperator (.). 
-        Der Elementzugriffsoperator wird als Punkt zwischen dem Namen der Strukturvariablen und dem 
-        Strukturelement codiert, auf das wir zugreifen möchten. 
-        Man würde das Schlüsselwort struct verwenden, um Variablen vom Strukturtyp zu definieren. 
+        Um auf ein Mitglied einer Struktur zuzugreifen, verwenden wir den Elementzugriffsoperator (.).
+        Der Elementzugriffsoperator wird als Punkt zwischen dem Namen der Strukturvariablen und dem
+        Strukturelement codiert, auf das wir zugreifen möchten.
+        Man würde das Schlüsselwort struct verwenden, um Variablen vom Strukturtyp zu definieren.
         Das folgende Beispiel erläutert die Verwendung der Struktur:
     */
     

--- a/OOP Einführung/Templates/Templates/Templates.cpp
+++ b/OOP Einführung/Templates/Templates/Templates.cpp
@@ -8,10 +8,10 @@
 #include <iostream>
 
 /*
-    In C ++ können zwei verschiedene Funktionen denselben Namen haben, 
-    wenn ihre Parameter unterschiedlich sind. entweder weil sie eine andere Anzahl 
-    von Parametern haben oder weil einer ihrer Parameter von einem anderen Typ ist. 
-    Als beispiel nehme ich das Beispiel aus Überladenen Funktionen 
+    In C ++ können zwei verschiedene Funktionen denselben Namen haben,
+    wenn ihre Parameter unterschiedlich sind. entweder weil sie eine andere Anzahl
+    von Parametern haben oder weil einer ihrer Parameter von einem anderen Typ ist.
+    Als beispiel nehme ich das Beispiel aus Überladenen Funktionen
     @see https://github.com/sebcodes/cpp-basycs/tree/master/Funktionen/Funktionen
 
     Wo wir 2 Funktionen habe für unterschiedliche Datentypen.
@@ -22,18 +22,18 @@
     Ein Template wird mit "template" deklariert, danach kommt die definierte "Klasse" (Klassen erkläre ich demnächst)
     Damit hätten wir schon mal das Template erstellt, jetzt befüllen wir es mit Funktionen oder einfach Variablen
 
-    Die Funktionssumme könnte für viele Typen überladen sein, und es könnte sinnvoll sein, 
-    dass alle denselben Körper haben. In solchen Fällen kann C ++ Funktionen mit generischen Typen definieren, 
-    die als Funktionsvorlagen bezeichnet werden. Das Definieren einer Funktionsvorlage folgt der gleichen Syntax 
-    wie eine reguläre Funktion, außer dass das Schlüsselwort template und eine Reihe von Vorlagenparametern in 
+    Die Funktionssumme könnte für viele Typen überladen sein, und es könnte sinnvoll sein,
+    dass alle denselben Körper haben. In solchen Fällen kann C ++ Funktionen mit generischen Typen definieren,
+    die als Funktionsvorlagen bezeichnet werden. Das Definieren einer Funktionsvorlage folgt der gleichen Syntax
+    wie eine reguläre Funktion, außer dass das Schlüsselwort template und eine Reihe von Vorlagenparametern in
     spitzen Klammern <> vorangestellt sind:
 
         Template <Template-Parameter> Funktionsdeklaration
 
     Die Vorlagenparameter sind eine Reihe von Parametern, 
-    die durch Kommas getrennt sind. Diese Parameter können generische Vorlagentypen sein, 
-    indem entweder das Schlüsselwort class oder typename gefolgt von einem Bezeichner angegeben wird. 
-    Dieser Bezeichner kann dann in der Funktionsdeklaration verwendet werden, als wäre es ein regulärer Typ. 
+    die durch Kommas getrennt sind. Diese Parameter können generische Vorlagentypen sein,
+    indem entweder das Schlüsselwort class oder typename gefolgt von einem Bezeichner angegeben wird.
+    Dieser Bezeichner kann dann in der Funktionsdeklaration verwendet werden, als wäre es ein regulärer Typ.
     Zum Beispiel könnte eine generische Summenfunktion definiert werden als:
 
 
@@ -49,16 +49,16 @@ Benutzer setName(Benutzer name, Benutzer nachname) {
 }
 
 /*
-    Es spielt keine Rolle, ob der generische Typ in der Liste der Vorlagenargumente mit der Schlüsselwortklasse oder 
+    Es spielt keine Rolle, ob der generische Typ in der Liste der Vorlagenargumente mit der Schlüsselwortklasse oder
     dem Schlüsselworttyp angegeben wird (dies sind 100% Synonyme in Vorlagendeklarationen).
 
-    Es spielt keine Rolle, ob der generische Typ in der Liste der Vorlagenargumente mit der Schlüsselwortklasse oder 
+    Es spielt keine Rolle, ob der generische Typ in der Liste der Vorlagenargumente mit der Schlüsselwortklasse oder
     dem Schlüsselworttyp angegeben wird (dies sind 100% Synonyme in Vorlagendeklarationen).
 
-    Wenn wir im obigen Code "Benutzer" deklarieren (ein generischer Typ innerhalb der in spitzen Klammern eingeschlossenen 
-    Vorlagenparameter), kann SomeType wie jeder andere Typ an einer beliebigen Stelle in der Funktionsdefinition verwendet 
-    werden. Es kann als Typ für Parameter, als Rückgabetyp oder zum Deklarieren neuer Variablen dieses Typs verwendet werden. 
-    In allen Fällen handelt es sich um einen generischen Typ, der zum Zeitpunkt der Instanziierung 
+    Wenn wir im obigen Code "Benutzer" deklarieren (ein generischer Typ innerhalb der in spitzen Klammern eingeschlossenen
+    Vorlagenparameter), kann SomeType wie jeder andere Typ an einer beliebigen Stelle in der Funktionsdefinition verwendet
+    werden. Es kann als Typ für Parameter, als Rückgabetyp oder zum Deklarieren neuer Variablen dieses Typs verwendet werden.
+    In allen Fällen handelt es sich um einen generischen Typ, der zum Zeitpunkt der Instanziierung
     der Vorlage festgelegt wird.
 */
 

--- a/Schleifen/DoWhile/DoWhile/DoWhile.cpp
+++ b/Schleifen/DoWhile/DoWhile/DoWhile.cpp
@@ -8,16 +8,15 @@
 #include <iostream>
 
 /*
-    Eine DoWhileSchleife ist eine Fußgesteuerte Schleife,  
+    Eine DoWhileSchleife ist eine Fußgesteuerte Schleife,
     sie läuft immer einmal durch bis die bedingung kommt und ab dann nur solange die bedingung wahr ist.
 
 
     Struktur:
-    do{
-    Anweisung1; 
-    Anweisung2;
-    }
-    while (Bedingung);
+    do {
+        Anweisung1;
+        Anweisung2;
+    } while (Bedingung);
 
 
 
@@ -29,8 +28,8 @@ int main()
     //Beispiel wo die schleife 10 mal durchläuft
     int i = 1;
     do {
-        std::cout << "Durchlauf: " << i << std::endl;
-        //i wird erhöht, da es sonst unendlich durchläuft da i immer kleiner 10 ist und somit die Bedingung wahr ist.
+        std::cout << "Durchlauf: " << i << "\n";
+        //i wird erhöht, da es sonst unendlich durchläuft, da i dann immer kleiner 10 ist und somit die Bedingung wahr ist.
         i++;
     } while (i <= 10);
 

--- a/Schleifen/ForSchleife/ForSchleife/ForSchleife.cpp
+++ b/Schleifen/ForSchleife/ForSchleife/ForSchleife.cpp
@@ -11,7 +11,7 @@ int main()
 {
 
 
-    /* Eine For-Schleife besteht aus 3 Bestandteilen, 
+    /* Eine For-Schleife besteht aus 3 Bestandteilen,
        1. der lokalen Variablen Definition (Variable ist nur in der Schleife gültig)
        2. der Bedingung zb. (i < 10)  -> i ist dabei die lokale variable
        3. die Inkrementierung/Dekrementierung der Lokalen Variable zb. i++ (ist das selbe wie i = i+1)
@@ -35,34 +35,34 @@ int main()
     // 9.Durchlauf: i = 8
     // 10.Durchlauf: i = 9
 
-    std::cout << "Beispiel wo immer i +1  genommen wird:" << std::endl;
+    std::cout << "Beispiel wo immer i +1  genommen wird:" << "\n";
 
     for (int i = 0; i < 10; i++)
     {
-        std::cout << "Durchlauf: " << i << std::endl;
+        std::cout << "Durchlauf: " << i << "\n";
     }
 
 
     /*
     Beispiel wo immer i + 2 genommen wird:
     */
-    std::cout << "Beispiel wo immer i + 2 genommen wird:" << std::endl;
+    std::cout << "Beispiel wo immer i + 2 genommen wird:" << "\n";
 
-    //Durchlauf:  0
-    //Durchlauf:  2
-    //Durchlauf : 4
-    //Durchlauf : 6
-    //Durchlauf : 8
+    //Durchlauf: 0
+    //Durchlauf: 2
+    //Durchlauf: 4
+    //Durchlauf: 6
+    //Durchlauf: 8
 
     for (int i = 0; i < 10; i = i+2)
     {
-        std::cout << "Durchlauf: " << i << std::endl;
+        std::cout << "Durchlauf: " << i << "\n";
     }
 
     /* 
-    wichtig : "i" oder wie ihr es nennt kann ich nur in der for verwenden, 
-    da dies eine lokale variable ist und sie ihren gültigkeitsbereich nur in der schleife hat, 
-    da sie sort definiert wird
+    Wichtig: die Schleifenvariable (hier i) kann ich nur innerhalb der for-Schleife verwenden,
+    da diese eine lokale variable ist und sie ihren gültigkeitsbereich nur in der schleife hat,
+    da sie dort definiert wird
     */
 
     /*
@@ -75,21 +75,21 @@ int main()
         if (i == 4) {
             break;
         }
-        std::cout << i << std::endl;
+        std::cout << i << "\n";
     }
 
     /*
 
-     Überspringen in einer Schleife mit "continue"
+        Überspringen in einer Schleife mit "continue"
 
- */
+    */
     for (int i = 0; i < 10; i++) {
-        //Wenn i = 4 ist soll die schleife die weitere Anweisung (also das cout) 
+        //Wenn i = 4 ist soll die schleife die weitere Anweisung (also das cout)
         //überspringen und in den nächsten Durchlauf gehen.
         if (i == 4) {
             continue;
         }
-        std::cout << i << std::endl;
+        std::cout << i << "\n";
     }
 
 

--- a/Schleifen/WhileSchleife/WhileSchleife/WhileSchleife.cpp
+++ b/Schleifen/WhileSchleife/WhileSchleife/WhileSchleife.cpp
@@ -8,12 +8,12 @@
 #include <iostream>
 
 /*
-    Eine WhileSchleife ist eine Kopfgesteuerte Schleife,  sie läuft solange wie die bedingung wahr ist.
+    Eine WhileSchleife ist eine Kopfgesteuerte Schleife, sie läuft solange die bedingung wahr ist.
 
     Struktur:
     while (Bedingung){
-    Anweisung1; 
-    Anweisung2;
+        Anweisung1; 
+        Anweisung2;
     }
 
 


### PR DESCRIPTION
std::endl flusht stdout jedes mal, wenn es benutzt wird, ist deshalb selten nützlich und sollte im Regelfall durch \n ersetzt werden.

Trailing whitespace in Kommentaren nervt.

Hab n paar Kommentare (imo) verständlicher formuliert

Wenn ihr irgendwas nicht wollt: Es ist euer Guide, ich hab da eig nichts mitzureden.
(Falls Fragen sind: bin auf dem HBNK-Discord, Timo)
